### PR TITLE
added background-color to nav-btns

### DIFF
--- a/styles/browser-plus.less
+++ b/styles/browser-plus.less
@@ -214,9 +214,11 @@ webview::shadow{
 }
 
 .nav-btns-left{
+  background-color: #21252b;
   float:left;
 }
 
 .nav-btns-right{
+  background-color: #21252b;
   float:right;
 }


### PR DESCRIPTION
I use maximize-panes (https://github.com/santip/maximize-panes) and when I maximize the browser pane, I can see my code through the nav bar. This fixes that bug.
